### PR TITLE
fix: fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -8,15 +8,14 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.12.0
+    rev: v4.13.7  # Use the latest version or a specific version
     hooks:
       - id: commitizen
-      - id: commitizen-branch
-        stages: [pre-push]
+        stages: [commit-msg]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.13
+    rev: v0.15.0
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "pre-commit>=4.5.1",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,9 @@ wheels = [
 name = "dungeonpy"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pre-commit" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -153,6 +156,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pre-commit", specifier = ">=4.5.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
**Pre-commit configuration updates:**

* Upgraded the `pre-commit-hooks` repository from version `v3.2.0` to `v6.0.0` in `.pre-commit-config.yaml`, ensuring the latest hooks and bug fixes are used.
* Updated the `commitizen` hook from version `v4.12.0` to `v4.13.7` and changed its stage to `commit-msg` for better commit message enforcement.
* Removed the `commitizen-branch` hook and its `pre-push` stage, simplifying the commit workflow.
* Upgraded the `ruff-pre-commit` linter from version `v0.14.13` to `v0.15.0` to use the latest linter improvements.

**Project dependency updates:**

* Added `pre-commit>=4.5.1` as a required dependency in `pyproject.toml` to ensure the project can run pre-commit hooks locally.