### PR TITLE
add new `get_actions` method to `Hero` 

### DIFF
--- a/src/domain/hero.py
+++ b/src/domain/hero.py
@@ -57,3 +57,10 @@ class Hero(Entity):
             choice (int): selected attribute to upgrade.
         """
         pass
+
+    @abstractmethod
+    def get_actions(self) -> dict:
+        """
+        Mapping of action keys to action details.
+        """
+        pass

--- a/src/domain/warrior.py
+++ b/src/domain/warrior.py
@@ -121,3 +121,19 @@ class Warrior(Hero):
         self.armor = self.normal_state["armor"]
 
         self.normal_state = {}
+
+    def get_actions(self) -> dict:
+        """
+        Returns available combat actions for this archetype.
+        """
+
+        return {
+            "1": {
+                "description": "Atacar (ataque básico com arma)",
+                "method": self.strike,
+            },
+            "2": {
+                "description": "Fúria (dobra ataque, sacrifica defesa)",
+                "method": self.to_rage,
+            },
+        }

--- a/tests/domain/test_hero.py
+++ b/tests/domain/test_hero.py
@@ -16,6 +16,9 @@ class ConcreteHero(Hero):
     def upgrade(self, points: int, choice: int) -> None:
         pass
 
+    def get_actions(self):
+        pass
+
 
 def test_hero_cannot_be_instantiated_directly():
     with pytest.raises(TypeError):
@@ -47,6 +50,9 @@ def test_missing_strike_raises():
         def upgrade(self, points, choice):
             pass
 
+        def get_actions(self):
+            pass
+
     with pytest.raises(TypeError):
         Incomplete("X", 100, 100, 10, 5)
 
@@ -59,6 +65,9 @@ def test_missing_damage_received_raises():
         def upgrade(self, points, choice):
             pass
 
+        def get_actions(self):
+            pass
+
     with pytest.raises(TypeError):
         Incomplete("X", 100, 100, 10, 5)
 
@@ -69,6 +78,24 @@ def test_missing_upgrade_raises():
             pass
 
         def damage_received(self, value, strike_element):
+            pass
+
+        def get_actions(self):
+            pass
+
+    with pytest.raises(TypeError):
+        Incomplete("X", 100, 100, 10, 5)
+
+
+def test_missing_actions_raises():
+    class Incomplete(Hero):
+        def strike(self, target, strike_element):
+            pass
+
+        def damage_received(self, value, strike_element):
+            pass
+
+        def upgrade(self, points, choice):
             pass
 
     with pytest.raises(TypeError):

--- a/tests/domain/test_warrior.py
+++ b/tests/domain/test_warrior.py
@@ -165,3 +165,26 @@ def test_rage():
     assert sample_warrior.attack == 25
     assert sample_warrior.shield == 10
     assert sample_warrior.armor == 10
+
+
+def test_get_actions():
+    sample_warrior: Warrior = Warrior(
+        name="Errant Knight",
+        max_life=200,
+        current_life=100,
+        attack=25,
+        speed=25,
+        shield=10,
+        armor=10,
+    )
+
+    assert sample_warrior.get_actions() == {
+        "1": {
+            "description": "Atacar (ataque básico com arma)",
+            "method": sample_warrior.strike,
+        },
+        "2": {
+            "description": "Fúria (dobra ataque, sacrifica defesa)",
+            "method": sample_warrior.to_rage,
+        },
+    }


### PR DESCRIPTION
This pull request introduces a new abstract method, `get_actions`, to the `Hero` class hierarchy, ensuring all hero archetypes define their available actions. The `Warrior` class now implements this method, providing a mapping of action keys to their descriptions and corresponding methods. Comprehensive tests have been added and updated to verify this new contract and its correct implementation.

### Core functionality changes

* Added the abstract method `get_actions` to the `Hero` base class, requiring subclasses to specify available actions.
* Implemented `get_actions` in the `Warrior` class, returning a dictionary mapping action keys to their descriptions and methods (e.g., basic attack and rage mode).

### Testing improvements

* Updated test hero subclasses in `test_hero.py` to include stub implementations of `get_actions`, ensuring they fulfill the new abstract method contract. [[1]](diffhunk://#diff-56687f9bfe1b0dde2416dd07fc77f806d61883e291ca44a0185665f858715032R19-R21) [[2]](diffhunk://#diff-56687f9bfe1b0dde2416dd07fc77f806d61883e291ca44a0185665f858715032R53-R55) [[3]](diffhunk://#diff-56687f9bfe1b0dde2416dd07fc77f806d61883e291ca44a0185665f858715032R68-R70) [[4]](diffhunk://#diff-56687f9bfe1b0dde2416dd07fc77f806d61883e291ca44a0185665f858715032R83-R100)
* Added a test to confirm that instantiating a `Hero` subclass without implementing `get_actions` raises a `TypeError`.
* Added a test in `test_warrior.py` to verify that `Warrior.get_actions` returns the expected dictionary of actions.